### PR TITLE
Converter input is now *http.Request

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,14 +1,14 @@
 coverage:
   precision: 2
   round: down
-  range: "50...90"
+  range: "85...100"
   status:
     project:
       default:
-        target: 75%
+        target: 90%
         threshold: 5%
         only_pulls: true
     patch:
       default:
-        target: 60%
+        target: 80%
         threshold: 10%

--- a/internal/api/handler/sparkpost.go
+++ b/internal/api/handler/sparkpost.go
@@ -1,9 +1,7 @@
 package handler
 
 import (
-	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"strconv"
@@ -12,7 +10,7 @@ import (
 	"github.com/eexit/http2smtp/internal/smtp"
 )
 
-const idLenght = 10000000000000000
+const spIDLenght = 10000000000000000
 
 type results struct {
 	ID                      string `json:"id"`
@@ -23,14 +21,6 @@ type results struct {
 // SparkPost handles SparkPost transmission API calls
 func SparkPost(smtpClient smtp.Client, converterProvider converter.Provider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			(json.NewEncoder(w).Encode(map[string]string{"error": err.Error()}))
-			return
-		}
-		defer r.Body.Close()
-
 		converter, err := converterProvider.Get(converter.SparkPostID)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
@@ -38,7 +28,7 @@ func SparkPost(smtpClient smtp.Client, converterProvider converter.Provider) htt
 			return
 		}
 
-		message, err := converter.Convert(bytes.NewReader(body))
+		message, err := converter.Convert(r)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			(json.NewEncoder(w).Encode(map[string]string{"error": err.Error()}))
@@ -58,7 +48,7 @@ func SparkPost(smtpClient smtp.Client, converterProvider converter.Provider) htt
 		}{
 			Results: results{
 				TotalAcceptedRecipients: sentCount,
-				ID:                      strconv.Itoa(rand.Intn(idLenght)),
+				ID:                      strconv.Itoa(rand.Intn(spIDLenght)),
 			},
 		}))
 	}

--- a/internal/api/handler/sparkpost_test.go
+++ b/internal/api/handler/sparkpost_test.go
@@ -28,15 +28,6 @@ func TestSparkPost(t *testing.T) {
 		wantBody string
 	}{
 		{
-			name: "request body failed to read",
-			args: args{
-				converterProvider: converter.NewProvider(),
-				requestBody:       &failingReader{},
-			},
-			wantCode: http.StatusInternalServerError,
-			wantBody: `{"error":"read error"}`,
-		},
-		{
 			name: "no converter for this route",
 			args: args{
 				converterProvider: converter.NewProvider(),
@@ -113,10 +104,4 @@ func TestSparkPost(t *testing.T) {
 			}
 		})
 	}
-}
-
-type failingReader struct{}
-
-func (*failingReader) Read(p []byte) (n int, err error) {
-	return 0, errors.New("read error")
 }

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -93,8 +93,8 @@ func (p *provider) Get(cid ID) (Converter, error) {
 	return nil, fmt.Errorf("converter ID %v not found", cid)
 }
 
-// readBody dumps a request body without altering the given request body
-func readBody(r *http.Request) (io.ReadSeeker, error) {
+// slurpBody idempotently copies a request's body
+func slurpBody(r *http.Request) (io.ReadSeeker, error) {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		return nil, err

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -99,7 +99,8 @@ func readBody(r *http.Request) (io.ReadSeeker, error) {
 	if err != nil {
 		return nil, err
 	}
-	r.Body.Close()
+	defer r.Body.Close()
+
 	r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
 	return bytes.NewReader(body), nil
 }

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -1,11 +1,18 @@
 package converter
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"net/http"
 	"sort"
 	"sync"
+
+	validator "github.com/go-playground/validator/v10"
 )
+
+var val = validator.New()
 
 type (
 	// ID is a converter ID type
@@ -31,7 +38,7 @@ func (i ids) Less(a, b int) bool {
 // Converter converts an input to a ConvertedMessage
 type Converter interface {
 	ID() ID
-	Convert(data io.ReadSeeker) (*Message, error)
+	Convert(r *http.Request) (*Message, error)
 }
 
 // Provider exposes the provider methods
@@ -84,4 +91,15 @@ func (p *provider) Get(cid ID) (Converter, error) {
 		}
 	}
 	return nil, fmt.Errorf("converter ID %v not found", cid)
+}
+
+// readBody dumps a request body without altering the given request body
+func readBody(r *http.Request) (io.ReadSeeker, error) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	r.Body.Close()
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+	return bytes.NewReader(body), nil
 }

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -160,7 +160,7 @@ func Test_provider_Get(t *testing.T) {
 	}
 }
 
-func Test_readBody(t *testing.T) {
+func Test_slurpBody(t *testing.T) {
 	tests := []struct {
 		name    string
 		req     *http.Request
@@ -188,9 +188,9 @@ func Test_readBody(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := readBody(tt.req)
+			got, err := slurpBody(tt.req)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("readBody() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("slurpBody() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 
@@ -206,9 +206,10 @@ func Test_readBody(t *testing.T) {
 			gotAsStr := string(gotAsBytes)
 
 			if gotAsStr != tt.want {
-				t.Errorf("readBody() = %#v, want %#v", gotAsStr, tt.want)
+				t.Errorf("slurpBody() = %#v, want %#v", gotAsStr, tt.want)
 			}
 
+			// Ensures the request body is still there after the slurp
 			body, err := ioutil.ReadAll(tt.req.Body)
 			if err != nil {
 				t.Fatalf("request body read failed: %v", err)

--- a/internal/converter/message_test.go
+++ b/internal/converter/message_test.go
@@ -1,7 +1,6 @@
 package converter
 
 import (
-	"errors"
 	"io"
 	"reflect"
 	"strings"
@@ -252,10 +251,4 @@ func TestMessage_HasRecipients(t *testing.T) {
 			}
 		})
 	}
-}
-
-type failingReader struct{}
-
-func (*failingReader) Read(p []byte) (n int, err error) {
-	return 0, errors.New("read error")
 }

--- a/internal/converter/rfc5322.go
+++ b/internal/converter/rfc5322.go
@@ -22,7 +22,7 @@ func (rfc *rfc5322) ID() ID {
 }
 
 func (rfc *rfc5322) Convert(r *http.Request) (*Message, error) {
-	body, err := readBody(r)
+	body, err := slurpBody(r)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/converter/rfc5322.go
+++ b/internal/converter/rfc5322.go
@@ -2,7 +2,7 @@ package converter
 
 import (
 	"fmt"
-	"io"
+	"net/http"
 	"net/mail"
 	"strings"
 )
@@ -21,21 +21,25 @@ func (rfc *rfc5322) ID() ID {
 	return RFC5322ID
 }
 
-func (rfc *rfc5322) Convert(data io.ReadSeeker) (*Message, error) {
-	m, err := mail.ReadMessage(data)
+func (rfc *rfc5322) Convert(r *http.Request) (*Message, error) {
+	body, err := readBody(r)
+	if err != nil {
+		return nil, err
+	}
+
+	m, err := mail.ReadMessage(body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse input: %w", err)
 	}
 
-	// Resets the reader
-	(data.Seek(0, 0))
+	(body.Seek(0, 0))
 
 	return NewMessage(
 		m.Header.Get("From"),
 		parse(m.Header, "To"),
 		parse(m.Header, "Cc"),
 		parse(m.Header, "Bcc"),
-		data,
+		body,
 	), nil
 }
 

--- a/internal/converter/rfc5322_test.go
+++ b/internal/converter/rfc5322_test.go
@@ -2,6 +2,8 @@ package converter
 
 import (
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
@@ -20,44 +22,44 @@ func Test_NewRFC5322(t *testing.T) {
 func Test_rfc5322_Convert(t *testing.T) {
 	tests := []struct {
 		name    string
-		data    io.ReadSeeker
+		reqBody io.ReadSeeker
 		want    *Message
 		wantErr bool
 	}{
 		{
-			name: "simple message",
-			data: simpleMessage,
+			name:    "simple message",
+			reqBody: strings.NewReader(simpleMessage),
 			want: &Message{
 				from: "Test <test@example.com>",
 				to:   []string{"Bob <bob@example.com>"},
-				raw:  simpleMessage,
+				raw:  strings.NewReader(simpleMessage),
 			},
 			wantErr: false,
 		},
 		{
-			name: "message with cc",
-			data: messageWithCc,
+			name:    "message with cc",
+			reqBody: strings.NewReader(messageWithCc),
 			want: &Message{
 				from: "Test <test@example.com>",
 				to:   []string{"Bob <bob@example.com>"},
 				cc:   []string{"Alice <alice@example.com>", "bob@example.com"},
-				raw:  messageWithCc,
+				raw:  strings.NewReader(messageWithCc),
 			},
 			wantErr: false,
 		},
 		{
-			name: "message with bcc",
-			data: messageWithBcc,
+			name:    "message with bcc",
+			reqBody: strings.NewReader(messageWithBcc),
 			want: &Message{
 				from: "Test <test@example.com>",
 				bcc:  []string{"Bob <bob@example.com>", "Alice <alice@example.com>"},
-				raw:  messageWithBcc,
+				raw:  strings.NewReader(messageWithBcc),
 			},
 			wantErr: false,
 		},
 		{
 			name:    "message parsing error",
-			data:    strings.NewReader(" From: Test <test@example.com>"),
+			reqBody: strings.NewReader(" From: Test <test@example.com>"),
 			want:    nil,
 			wantErr: true,
 		},
@@ -65,33 +67,62 @@ func Test_rfc5322_Convert(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rfc := &rfc5322{}
-			got, err := rfc.Convert(tt.data)
+			got, err := rfc.Convert(httptest.NewRequest(http.MethodPost, "/", tt.reqBody))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("rfc5322.Convert() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("rfc5322.Convert() = %#v, want %#v", got, tt.want)
+			if tt.want == nil {
+				return
+			}
+
+			if got.From() != tt.want.From() {
+				t.Errorf("rfc5322.Convert.From() = %#v, want %#v", got.From(), tt.want.From())
+			}
+			if !reflect.DeepEqual(got.To(), tt.want.To()) {
+				t.Errorf("rfc5322.Convert.To() = %#v, want %#v", got.To(), tt.want.To())
+			}
+			if !reflect.DeepEqual(got.Cc(), tt.want.Cc()) {
+				t.Errorf("rfc5322.Convert.Cc() = %#v, want %#v", got.Cc(), tt.want.Cc())
+			}
+			if !reflect.DeepEqual(got.Bcc(), tt.want.Bcc()) {
+				t.Errorf("rfc5322.Convert.Bcc() = %#v, want %#v", got.Bcc(), tt.want.Bcc())
+			}
+
+			gotRaw, err := got.Raw()
+			if err != nil {
+				t.Fatalf("got message raw read failed: %v", err)
+			}
+			wantRaw, err := tt.want.Raw()
+			if err != nil {
+				t.Fatalf("want message raw read failed: %v", err)
+			}
+
+			gotRawString := string(gotRaw)
+			wantRawString := string(wantRaw)
+
+			if gotRawString != wantRawString {
+				t.Errorf("rfc5322.Convert.Raw() = %#v, want %#v", gotRawString, wantRawString)
 			}
 		})
 	}
 }
 
-var simpleMessage = strings.NewReader(`From: Test <test@example.com>
+var simpleMessage = `From: Test <test@example.com>
 To: Bob <bob@example.com>
 Subject: Hello world!
 
-Hello world!`)
+Hello world!`
 
-var messageWithCc = strings.NewReader(`From: Test <test@example.com>
+var messageWithCc = `From: Test <test@example.com>
 To: Bob <bob@example.com>
 Cc: Alice <alice@example.com>, bob@example.com
 Subject: Hello world!
 
-Hello world!`)
+Hello world!`
 
-var messageWithBcc = strings.NewReader(`From: Test <test@example.com>
+var messageWithBcc = `From: Test <test@example.com>
 Bcc: Bob <bob@example.com>,Alice <alice@example.com>
 Subject: Hello world!
 
-Hello world!`)
+Hello world!`

--- a/internal/converter/rfc5322_test.go
+++ b/internal/converter/rfc5322_test.go
@@ -22,7 +22,7 @@ func Test_NewRFC5322(t *testing.T) {
 func Test_rfc5322_Convert(t *testing.T) {
 	tests := []struct {
 		name    string
-		reqBody io.ReadSeeker
+		reqBody io.Reader
 		want    *Message
 		wantErr bool
 	}{
@@ -60,6 +60,12 @@ func Test_rfc5322_Convert(t *testing.T) {
 		{
 			name:    "message parsing error",
 			reqBody: strings.NewReader(" From: Test <test@example.com>"),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "body read error",
+			reqBody: &failingReader{},
 			want:    nil,
 			wantErr: true,
 		},

--- a/internal/converter/sparkpost_test.go
+++ b/internal/converter/sparkpost_test.go
@@ -36,10 +36,16 @@ func Test_spt10n_ID(t *testing.T) {
 func Test_spt10n_Convert(t *testing.T) {
 	tests := []struct {
 		name    string
-		reqBody io.ReadSeeker
+		reqBody io.Reader
 		wantNil bool
 		wantErr bool
 	}{
+		{
+			name:    "body read error",
+			reqBody: &failingReader{},
+			wantNil: true,
+			wantErr: true,
+		},
 		{
 			name:    "data is not valid json",
 			reqBody: strings.NewReader("<html></html>"),

--- a/internal/converter/stub.go
+++ b/internal/converter/stub.go
@@ -1,6 +1,6 @@
 package converter
 
-import "io"
+import "net/http"
 
 // StubConverterID is the Stub converter ID
 const StubConverterID ID = "stub"
@@ -23,6 +23,6 @@ func (s *Stub) ID() ID {
 
 // Convert implements the Converter interface. It returns the stub
 // message and error.
-func (s *Stub) Convert(data io.ReadSeeker) (*Message, error) {
+func (s *Stub) Convert(r *http.Request) (*Message, error) {
 	return s.Message, s.Err
 }


### PR DESCRIPTION
This change allows future converters to process the whole request instead of just its body. Some vendors rely on query strings or forms and the idea behind converters is to convert an HTTP request into a Message. With this change, the idea is now better fulfilled.